### PR TITLE
Rate-type token-bucket 아닐 경우Handler 중복 등록 이슈 해결

### DIFF
--- a/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
+++ b/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
@@ -64,7 +64,7 @@ public class RateLimiterAutoConfiguration {
     @Bean
     @ConditionalOnBean({RedisTemplate.class, BucketProperties.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
-    public CacheTemplate bucketRedisTemplate(
+    public BucketRedisTemplate bucketRedisTemplate(
         RedisTemplate<String, AbstractTokenInfo> redisTokenInfoTemplate,
         BucketProperties bucketProperties
     ) {


### PR DESCRIPTION
## 연결된 이슈
#3 처리율 제한 설정 빈 등록 오류

## 이슈 원인
기본 값으로 등록되던 `BucketRedisTemplate` 가 존재해서 해당 타입의 빈이 또 다시 생성될 경우 어떤 빈을 찾아갈 지 찾을 수 없는 오류가 발생함.

## 해결 방법
`TokenBucketHandler ` 을 인터페이스인 `RateLimitHandler `을 반환하도록 변경하고 해당 빈을 property 에서 `rate-limiter.rate-type` = `token_bucket ` 일 경우에만 생성 되도록 변경

## 기타 변경 사항
`BucketRedisTemplate`를 반환하던 빈을 인터페이스인 `CacheTemplate`를 리턴하도록 수정

## 주의사항 
없음.