### PR TITLE
fix : github action version up 방식 수정

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,10 +19,8 @@ jobs:
         run: |
           # Get the branch name from the push event
           BRANCH_NAME=$(git log -1 --pretty=%B | sed -n 's/.*Merge pull request #.* from //p')
-
           # Extract the prefix (major, minor, patch) from the branch name
           VERSION_BUMP=$(echo "$BRANCH_NAME" | awk -F'/' '{print tolower($1)}')
-
           # Validate the bump type
           case "$VERSION_BUMP" in
             major|minor|patch) 
@@ -31,7 +29,6 @@ jobs:
               echo "Invalid version bump type. Defaulting to patch."
               VERSION_BUMP="patch";;
           esac
-
           echo "Branch name: $BRANCH_NAME"
           echo "Version bump type: $VERSION_BUMP"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
@@ -40,11 +37,8 @@ jobs:
       - name: Get current version tag and bump if exists
         id: get_version
         run: |
-          # Get all tags and sort them to find the latest tag
-          LATEST_TAG=$(git tag --list | sort -V | tail -n 1)
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0" # Default if no tags exist
-          fi
+          # Get the latest tag from the repository
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "v0.0.0")
           echo "Latest tag: $LATEST_TAG"
 
           # Parse the version into MAJOR, MINOR, PATCH
@@ -52,22 +46,20 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
           # Increment based on the bump type
-          while git rev-parse "v$MAJOR.$MINOR.$PATCH" >/dev/null 2>&1; do
-            case "$VERSION_BUMP" in
-              major)
-                MAJOR=$((MAJOR + 1))
-                MINOR=0
-                PATCH=0
-                ;;
-              minor)
-                MINOR=$((MINOR + 1))
-                PATCH=0
-                ;;
-              patch)
-                PATCH=$((PATCH + 1))
-                ;;
-            esac
-          done
+          case "$VERSION_BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
 
           # Create new version
           NEW_VERSION="v$MAJOR.$MINOR.$PATCH"


### PR DESCRIPTION
## 수정내용
1. 최신 태그 가져오는 로직 수정
문제: 이전 코드에서 git tag --list | sort -V | tail -n 1은 최신 태그를 제대로 가져오지 못하거나 비어 있는 경우 잘못된 결과를 반환했습니다.
해결: 최신 태그를 가져오는 명령어를 개선했습니다.
2. 버전 증가 로직 개선
문제: 동일 태그(v0.0.0 등)가 이미 존재하는 경우에도 태그를 다시 생성하려 시도해 충돌이 발생했습니다.
해결: 태그가 중복되지 않도록 최신 태그를 가져온 후 새로운 태그를 정확히 계산하는 로직을 추가했습니다.
중복된 태그가 발생하지 않도록 최신 태그를 기반으로 버전을 계산합니다.