### PR TITLE
fix : github action version up

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,18 +34,21 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "VERSION_BUMP=$VERSION_BUMP" >> $GITHUB_ENV
 
-      - name: Get current version tag and bump if exists
+      - name: Get current version tag and calculate next version
         id: get_version
         run: |
-          # Get the latest tag from the repository
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "v0.0.0")
+          # Get all tags and sort them to find the latest tag
+          LATEST_TAG=$(git tag --list | sort -V | tail -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0" # Default if no tags exist
+          fi
           echo "Latest tag: $LATEST_TAG"
 
           # Parse the version into MAJOR, MINOR, PATCH
           VERSION=${LATEST_TAG//v/}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          # Increment based on the bump type
+          # Increment the version based on the bump type
           case "$VERSION_BUMP" in
             major)
               MAJOR=$((MAJOR + 1))
@@ -61,7 +64,7 @@ jobs:
               ;;
           esac
 
-          # Create new version
+          # Create the next version
           NEW_VERSION="v$MAJOR.$MINOR.$PATCH"
           echo "New version: $NEW_VERSION"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## 최신 태그를 올바르게 가져오는 로직 추가 
1. 기존 문제:
최신 태그를 제대로 가져오지 못하거나, 태그가 없는 경우 기본값을 잘못 설정하여 잘못된 결과를 반환. 태그 목록이 잘못 정렬되거나, 가장 마지막 태그를 가져오지 못함.

2. 수정 내용:
- git tag --list | sort -V | tail -n 1:
모든 태그를 버전 순으로 정렬하고, 가장 마지막 태그를 가져옵니다.
- if [ -z "$LATEST_TAG" ];:
태그가 없는 경우 기본값 v0.0.0을 설정하여 안전하게 동작합니다.