### PR TITLE
refactor: pure 레벨로 디펜던시 낮춤

### DIFF
--- a/rate-limiter-spring-boot-autoconfigure/build.gradle
+++ b/rate-limiter-spring-boot-autoconfigure/build.gradle
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.0' apply false
@@ -29,31 +31,25 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom SpringBootPlugin.BOM_COORDINATES
     }
 }
 
 dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
-    implementation 'org.redisson:redisson-spring-boot-starter:3.27.1'
     implementation project(':rate-limiter')
-    implementation 'org.springframework.boot:spring-boot-starter'
+    // https://mvnrepository.com/artifact/org.redisson/redisson
+    implementation 'org.redisson:redisson:3.40.2'
+    // https://mvnrepository.com/artifact/io.lettuce/lettuce-core
+    implementation 'io.lettuce:lettuce-core:6.5.1.RELEASE'
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-autoconfigure
+    implementation 'org.springframework.boot:spring-boot-autoconfigure'
+    // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.2'
+
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 test {
     useJUnitPlatform()
-}
-
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = 'com.innercicle'
-            artifactId = 'rate-limiter-spring-boot-autoconfigure'
-            version = '0.0.1'
-
-            from components.java
-        }
-    }
 }

--- a/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
+++ b/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
@@ -1,5 +1,8 @@
 package com.innercicle;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.innercicle.aop.RateLimitAop;
 import com.innercicle.aop.RateLimitingProperties;
 import com.innercicle.cache.BucketRedisTemplate;
@@ -13,24 +16,22 @@ import com.innercicle.handler.TokenBucketHandler;
 import com.innercicle.lock.ConcurrentHashMapManager;
 import com.innercicle.lock.LockManager;
 import com.innercicle.lock.RedisRedissonManager;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.RedisCodec;
+import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.redisson.config.Config;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
-@ConditionalOnClass(RedisProperties.class)
-@AutoConfigureBefore(RedisAutoConfiguration.class)
 public class RateLimiterAutoConfiguration {
 
     @Bean
@@ -40,67 +41,59 @@ public class RateLimiterAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
+    public RedisProperties redisProperties() {
+        return new RedisProperties();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
     public BucketProperties bucketProperties() {
         return new BucketProperties(); // 필요한 초기값 설정 가능
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
-    public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    @ConditionalOnProperty(prefix = "rate-limiter", value = "lock-type", havingValue = "redis_redisson")
+    public RedissonClient redissonClient(RedisProperties redisProperties) {
+        String redisUri = String.format("redis://%s:%d", redisProperties.getHost(), redisProperties.getPort());
+        Config config = new Config();
+        config.useSingleServer().setAddress(redisUri);
+        return Redisson.create(config);
     }
 
     @Bean
-    @ConditionalOnBean({RedisConnectionFactory.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
-    public RedisTemplate<String, AbstractTokenInfo> redisTokenInfoTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, AbstractTokenInfo> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-        redisTemplate.setKeySerializer(RedisSerializer.string());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-        return redisTemplate;
+    public RedisClient redisClient(RedisProperties redisProperties) {
+        String redisUri = String.format("redis://%s:%d", redisProperties.getHost(), redisProperties.getPort());
+        return RedisClient.create(redisUri);
     }
 
     @Bean
-    @ConditionalOnBean({RedisTemplate.class, BucketProperties.class})
+    @ConditionalOnBean({RedisClient.class})
+    @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
+    public StatefulRedisConnection<String, AbstractTokenInfo> redisConnection(RedisClient redisClient) {
+        return redisClient.connect(new AbstractTokenInfoCodec());
+    }
+
+    @Bean
+    @ConditionalOnBean({StatefulRedisConnection.class, BucketProperties.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
     public BucketRedisTemplate bucketRedisTemplate(
-        RedisTemplate<String, AbstractTokenInfo> redisTokenInfoTemplate,
+        StatefulRedisConnection<String, AbstractTokenInfo> redisTokenInfoTemplate,
         BucketProperties bucketProperties
     ) {
         return new BucketRedisTemplate(redisTokenInfoTemplate, bucketProperties);
     }
 
     @Bean
+    @ConditionalOnBean({RedissonClient.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "lock-type", havingValue = "redis_redisson")
-    public RedisRedissonManager redisRedissonManager(RedissonClient redissonClient) {
+    public LockManager redisRedissonManager(RedissonClient redissonClient) {
         return new RedisRedissonManager(redissonClient);
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = "rate-limiter", value = "cache-type", havingValue = "redis")
-    public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
-        return new GenericJackson2JsonRedisSerializer();
-    }
-
-    @Bean
-    @ConditionalOnBean({LockManager.class, TokenBucketHandler.class, RateLimitHandler.class})
-    public RateLimitAop rateLimitAop(RateLimitingProperties rateLimitingProperties,
-                                     LockManager lockManager,
-                                     RateLimitHandler rateLimitHandler) {
-        return new RateLimitAop(rateLimitingProperties, lockManager, rateLimitHandler);
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = "rate-limiter", value = "lock-type", havingValue = "concurrent_hash_map")
-    public ConcurrentHashMapManager concurrentHashMapManager() {
-        return new ConcurrentHashMapManager();
     }
 
     @Bean
     @ConditionalOnBean({BucketRedisTemplate.class, BucketProperties.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "rate-type", havingValue = "token_bucket")
-
     public RateLimitHandler tokenBucketHandler(
         BucketRedisTemplate bucketRedisTemplate,
         BucketProperties bucketProperties
@@ -120,6 +113,67 @@ public class RateLimiterAutoConfiguration {
     @ConditionalOnProperty(prefix = "rate-limiter", value = "rate-type", havingValue = "fixed_window_counter")
     public RateLimitHandler fixedWindowCounterHandler(CacheTemplate cacheTemplate) {
         return new FixedWindowCounterHandler(cacheTemplate);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rate-limiter", value = "lock-type", havingValue = "concurrent_hash_map")
+    public ConcurrentHashMapManager concurrentHashMapManager() {
+        return new ConcurrentHashMapManager();
+    }
+
+    @Bean
+    @ConditionalOnBean({LockManager.class, RateLimitHandler.class})
+    public RateLimitAop rateLimitAop(RateLimitingProperties rateLimitingProperties,
+                                     LockManager lockManager,
+                                     RateLimitHandler rateLimitHandler) {
+        return new RateLimitAop(rateLimitingProperties, lockManager, rateLimitHandler);
+    }
+
+    static class AbstractTokenInfoCodec implements RedisCodec<String, AbstractTokenInfo> {
+
+        @Override
+        public String decodeKey(ByteBuffer bytes) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+
+        @Override
+        public AbstractTokenInfo decodeValue(ByteBuffer bytes) {
+            String json = StandardCharsets.UTF_8.decode(bytes).toString();
+            return deserialize(json);
+        }
+
+        @Override
+        public ByteBuffer encodeKey(String key) {
+            return StandardCharsets.UTF_8.encode(key);
+        }
+
+        @Override
+        public ByteBuffer encodeValue(AbstractTokenInfo value) {
+            String json = serialize(value);
+            return StandardCharsets.UTF_8.encode(json);
+        }
+
+        private AbstractTokenInfo deserialize(String json) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            try {
+                return objectMapper.readValue(json, AbstractTokenInfo.class);
+
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private String serialize(AbstractTokenInfo value) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            try {
+                return objectMapper.writeValueAsString(value);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
     }
 
 }

--- a/rate-limiter/build.gradle
+++ b/rate-limiter/build.gradle
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.0' apply false
@@ -26,33 +28,32 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom SpringBootPlugin.BOM_COORDINATES
     }
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // https://mvnrepository.com/artifact/org.springframework/spring-context
+    implementation 'org.springframework:spring-context:6.2.1'
+
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-configuration-processor
+    implementation 'org.springframework.boot:spring-boot-starter'
+
+    // https://mvnrepository.com/artifact/org.redisson/redisson
+    implementation 'org.redisson:redisson:3.40.2'
+    // https://mvnrepository.com/artifact/org.aspectj/aspectjtools
+    implementation 'org.aspectj:aspectjtools:1.9.22.1'
+    // https://mvnrepository.com/artifact/jakarta.servlet/jakarta.servlet-api
+    compileOnly 'jakarta.servlet:jakarta.servlet-api:6.1.0'
+    // https://mvnrepository.com/artifact/org.springframework/spring-web
+    implementation 'org.springframework:spring-web:6.2.1'
+    // https://mvnrepository.com/artifact/io.lettuce/lettuce-core
+    implementation 'io.lettuce:lettuce-core:6.5.1.RELEASE'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
-    implementation 'org.redisson:redisson-spring-boot-starter:3.27.1'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = 'com.innercicle'
-            artifactId = 'rate-limiter'
-            version = '0.0.1'
-
-            from components.java
-        }
-    }
 }
 
 tasks.named('test') {

--- a/rate-limiter/build.gradle
+++ b/rate-limiter/build.gradle
@@ -56,6 +56,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
 }

--- a/rate-limiter/src/main/java/com/innercicle/cache/BucketRedisTemplate.java
+++ b/rate-limiter/src/main/java/com/innercicle/cache/BucketRedisTemplate.java
@@ -2,9 +2,10 @@ package com.innercicle.cache;
 
 import com.innercicle.domain.AbstractTokenInfo;
 import com.innercicle.domain.BucketProperties;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
@@ -14,12 +15,14 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class BucketRedisTemplate implements CacheTemplate {
 
-    private final RedisTemplate<String, AbstractTokenInfo> redisTokenInfoTemplate;
+    private final StatefulRedisConnection<String, AbstractTokenInfo> connection;
     private final BucketProperties bucketProperties;
 
     @Override
     public AbstractTokenInfo getOrDefault(final String key, Class<? extends AbstractTokenInfo> clazz) {
-        return Optional.ofNullable(redisTokenInfoTemplate.opsForValue().get(key))
+        RedisCommands<String, AbstractTokenInfo> syncCommands = connection.sync();
+
+        return Optional.ofNullable(syncCommands.get(key))
             .orElseGet(() -> {
                 try {
                     return clazz.getDeclaredConstructor(BucketProperties.class).newInstance(bucketProperties);
@@ -31,7 +34,10 @@ public class BucketRedisTemplate implements CacheTemplate {
 
     @Override
     public void save(String key, AbstractTokenInfo tokenInfo) {
-        redisTokenInfoTemplate.opsForValue().set(key, tokenInfo, Duration.ofMillis(3_000));
+        RedisCommands<String, AbstractTokenInfo> syncCommands = connection.sync();
+
+        // Lettuce는 기본적으로 만료 시간을 세트할 때 `EX`(초) 또는 `PX`(밀리초) 옵션을 사용
+        syncCommands.setex(key, Duration.ofMillis(3_000).toSeconds(), tokenInfo);
     }
 
 }

--- a/rate-limiter/src/main/java/com/innercicle/domain/AbstractTokenInfo.java
+++ b/rate-limiter/src/main/java/com/innercicle/domain/AbstractTokenInfo.java
@@ -1,8 +1,16 @@
 package com.innercicle.domain;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TokenBucketInfo.class, name = "TokenBucketInfo"),
+    @JsonSubTypes.Type(value = FixedWindowCounter.class, name = "FixedWindowCounter"),
+    @JsonSubTypes.Type(value = LeakyBucketInfo.class, name = "LeakyBucketInfo")
+})
 @Getter
 @NoArgsConstructor
 public class AbstractTokenInfo {
@@ -32,7 +40,6 @@ public class AbstractTokenInfo {
     }
 
     public void endProcess() {
-
     }
 
 }


### PR DESCRIPTION
# 디펜던시 리팩토링

## 문제 
-  starter 와 같은 무거운 종속성을 가진 dependency 들이 존재하여 기본 기능보다 추가된 dependency 들이 더 무거움

## redisson, redis starter 제거
- starter 와 같은 무거운 종속성을 가진 dependency를 제거하고 가장 낮은 레벨의 dependency 를 추가.

## 작업
- spring-boot-starter-web 제거 -> spring-web:6.2.1, jakarta.servlet-api:6.1.0 추가
- spring-boot-starter-data-redis 제거 -> lettuce-core:6.5.1.RELEASE 추가
- redisson-spring-boot-starter:3.27.1 제거 -> redisson:3.40.2 추가

## 예외 사항
없음.
