### PR TITLE
Patch/feature/pure dependency

### DIFF
--- a/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
+++ b/rate-limiter-spring-boot-autoconfigure/src/main/java/com/innercicle/RateLimiterAutoConfiguration.java
@@ -102,10 +102,10 @@ public class RateLimiterAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean({BucketProperties.class})
+    @ConditionalOnBean({CacheTemplate.class, BucketProperties.class})
     @ConditionalOnProperty(prefix = "rate-limiter", value = "rate-type", havingValue = "leaky_bucket")
-    public RateLimitHandler leakyBucketHandler(BucketProperties bucketProperties) {
-        return new LeakyBucketHandler(bucketProperties);
+    public RateLimitHandler leakyBucketHandler(CacheTemplate cacheTemplate, BucketProperties bucketProperties) {
+        return new LeakyBucketHandler(cacheTemplate, bucketProperties);
     }
 
     @Bean

--- a/rate-limiter/src/main/java/com/innercicle/aop/RateLimitAop.java
+++ b/rate-limiter/src/main/java/com/innercicle/aop/RateLimitAop.java
@@ -31,9 +31,8 @@ public class RateLimitAop {
      * - RateLimiting 어노테이션이 붙은 메소드에 대한 Rate Limiting 처리 <br/>
      * - enable/disable 설정에 따라 Rate Limiting 처리 여부 결정 {@link RateLimitingProperties#isEnabled()} <br/>
      *
-     * @param joinPoint
-     * @return
-     * @throws Throwable
+     * @param joinPoint : AspectJ JoinPoint
+     * @return Object : 메소드 실행 결과
      */
     @Around("@annotation(com.innercicle.annotations.RateLimiting)")
     public Object rateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -58,7 +57,8 @@ public class RateLimitAop {
 
             Object proceed = joinPoint.proceed();
 
-            doEndProcess(tokenBucketInfo);
+            rateLimitHandler.endRequest();
+            setResponseHeader(tokenBucketInfo);
 
             return proceed;
         } catch (InterruptedException e) {
@@ -68,11 +68,6 @@ public class RateLimitAop {
             log.debug("{} lock 해제", this.getClass().getName());
             lockManager.unlock();
         }
-    }
-
-    private void doEndProcess(AbstractTokenInfo tokenBucketInfo) {
-        tokenBucketInfo.endProcess();
-        setResponseHeader(tokenBucketInfo);
     }
 
     private void tryLock(RateLimiting rateLimiting, String lockKey) throws InterruptedException {

--- a/rate-limiter/src/main/java/com/innercicle/domain/AbstractTokenInfo.java
+++ b/rate-limiter/src/main/java/com/innercicle/domain/AbstractTokenInfo.java
@@ -39,7 +39,4 @@ public class AbstractTokenInfo {
         return (int)(System.currentTimeMillis() - this.lastRefillTimestamp) / this.rate;
     }
 
-    public void endProcess() {
-    }
-
 }

--- a/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
+++ b/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
@@ -1,29 +1,31 @@
 package com.innercicle.domain;
 
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-import java.util.Deque;
-
-@Setter @NoArgsConstructor
+@NoArgsConstructor
 public class LeakyBucketInfo extends AbstractTokenInfo {
 
-    private Deque<LeakyBucketInfo> deque;
+    /**
+     * 큐에서 사용중인 갯수
+     */
+    private int usedCount;
 
-    public static LeakyBucketInfo of(int capacity) {
+    public static LeakyBucketInfo of(int dequeSize, int capacity) {
         LeakyBucketInfo leakyBucketInfo = new LeakyBucketInfo();
         leakyBucketInfo.capacity = capacity;
+        leakyBucketInfo.usedCount = dequeSize;
         return leakyBucketInfo;
     }
 
-    @Override
-    public int getLimit() {
-        return deque.size();
-    }
-
+    /**
+     * <h2>현재 큐에서 사용 가능한 갯수</h2>
+     * 전체 용량에서 현재 사용중인 갯수를 뺀다.<br/>
+     *
+     * @return 사용 가능한 갯수
+     */
     @Override
     public int getRemaining() {
-        return capacity - deque.size();
+        return capacity - usedCount;
     }
 
 }

--- a/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
+++ b/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
@@ -1,20 +1,22 @@
 package com.innercicle.domain;
 
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@NoArgsConstructor
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+@Getter
 public class LeakyBucketInfo extends AbstractTokenInfo {
+
+    private final Deque<LeakyBucketInfo> deque;
 
     /**
      * 큐에서 사용중인 갯수
      */
-    private int usedCount;
 
-    public static LeakyBucketInfo of(int dequeSize, int capacity) {
-        LeakyBucketInfo leakyBucketInfo = new LeakyBucketInfo();
-        leakyBucketInfo.capacity = capacity;
-        leakyBucketInfo.usedCount = dequeSize;
-        return leakyBucketInfo;
+    public LeakyBucketInfo(BucketProperties properties) {
+        super(properties);
+        this.deque = new ArrayDeque<>(properties.getCapacity());
     }
 
     /**
@@ -25,7 +27,7 @@ public class LeakyBucketInfo extends AbstractTokenInfo {
      */
     @Override
     public int getRemaining() {
-        return capacity - usedCount;
+        return capacity - deque.size();
     }
 
 }

--- a/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
+++ b/rate-limiter/src/main/java/com/innercicle/domain/LeakyBucketInfo.java
@@ -26,11 +26,4 @@ public class LeakyBucketInfo extends AbstractTokenInfo {
         return capacity - deque.size();
     }
 
-    @Override
-    public void endProcess() {
-        if (!deque.isEmpty()) {
-            deque.removeLast();
-        }
-    }
-
 }

--- a/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
+++ b/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
@@ -48,7 +48,9 @@ public class LeakyBucketHandler implements RateLimitHandler {
 
     @Override
     public void endRequest() {
-        this.deque.removeLast();
+        if (!deque.isEmpty()) {
+            deque.removeLast();
+        }
     }
 
     private void startLeakTask() {

--- a/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
+++ b/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
@@ -34,7 +34,6 @@ public class LeakyBucketHandler implements RateLimitHandler {
         LeakyBucketInfo leakyBucketInfo = (LeakyBucketInfo)cacheTemplate.getOrDefault("deque", LeakyBucketInfo.class);
         this.deque = leakyBucketInfo.getDeque();
         this.scheduler = Executors.newScheduledThreadPool(1);
-        this.capacity = bucketProperties.getCapacity();
         this.leakRate = bucketProperties.getRate();
         this.timeUnit = bucketProperties.getRateUnit().toTimeUnit();
         startLeakTask();

--- a/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
+++ b/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
@@ -1,12 +1,13 @@
 package com.innercicle.handler;
 
 import com.innercicle.advice.exceptions.RateLimitException;
+import com.innercicle.cache.CacheTemplate;
 import com.innercicle.domain.AbstractTokenInfo;
 import com.innercicle.domain.BucketProperties;
 import com.innercicle.domain.LeakyBucketInfo;
 import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
 
-import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -14,12 +15,14 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * <h2>누출 버킷 알고리즘을 사용하여 요청을 제한하는 핸들러</h2>
- * 해당 알고리즘은 단순 버킷 알고리즘과 다르게, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작합니다. <br/>
- * 이를 통해, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작합니다.<br/>
- * 따라서 키 값으로 동작하지 않고, 키와 관계 없이 요청이 들어오면 큐에 담아 두고 순서대로 처리합니다.
+ * 해당 알고리즘은 단순 버킷 알고리즘과 다르게, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작. <br/>
+ * 이를 통해, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작.<br/>
+ * 따라서 키 값으로 동작하지 않고, 키와 관계 없이 요청이 들어오면 큐에 담아 두고 순서대로 처리.<br/>
  */
+@RequiredArgsConstructor
 public class LeakyBucketHandler implements RateLimitHandler {
 
+    private final CacheTemplate cacheTemplate;
     private final Deque<LeakyBucketInfo> deque;
     private final int leakRate;                         // 누출 속도
     private final ScheduledExecutorService scheduler;   // 주기적으로 누출을 수행하는 스케줄러
@@ -27,8 +30,10 @@ public class LeakyBucketHandler implements RateLimitHandler {
     private final TimeUnit timeUnit;
 
     // Leaky Bucket 생성자
-    public LeakyBucketHandler(BucketProperties bucketProperties) {
-        this.deque = new ArrayDeque<>(bucketProperties.getCapacity());
+    public LeakyBucketHandler(CacheTemplate cacheTemplate, BucketProperties bucketProperties) {
+        this.cacheTemplate = cacheTemplate;
+        LeakyBucketInfo leakyBucketInfo = (LeakyBucketInfo)cacheTemplate.getOrDefault("deque", LeakyBucketInfo.class);
+        this.deque = leakyBucketInfo.getDeque();
         this.scheduler = Executors.newScheduledThreadPool(1);
         this.capacity = bucketProperties.getCapacity();
         this.leakRate = bucketProperties.getRate();
@@ -38,10 +43,10 @@ public class LeakyBucketHandler implements RateLimitHandler {
 
     @Override
     public AbstractTokenInfo allowRequest(String key) {
-        LeakyBucketInfo bucketInfo = LeakyBucketInfo.of(deque.size(), capacity);
+        LeakyBucketInfo bucketInfo = (LeakyBucketInfo)cacheTemplate.getOrDefault("deque", LeakyBucketInfo.class);
         if (deque.size() < bucketInfo.getCapacity()) {
             deque.add(bucketInfo);
-            if (scheduler.isShutdown()) {
+            if (scheduler.isShutdown()) {   // 스케줄러가 종료되었을 경우 재시작
                 startLeakTask();
             }
             return bucketInfo;
@@ -59,6 +64,10 @@ public class LeakyBucketHandler implements RateLimitHandler {
         }
     }
 
+    /**
+     * <h2>누출 작업을 시작.</h2>
+     * 큐에 있는 모든 요소를 누출 속도에 맞게 제거.
+     */
     private void startLeakTask() {
         this.scheduler.scheduleAtFixedRate(() -> {
             synchronized (LeakyBucketHandler.this) {

--- a/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
+++ b/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
@@ -12,6 +12,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * <h2>누출 버킷 알고리즘을 사용하여 요청을 제한하는 핸들러</h2>
+ * 해당 알고리즘은 단순 버킷 알고리즘과 다르게, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작합니다. <br/>
+ * 이를 통해, 토큰을 한 번에 모두 채우지 않고, 주기적으로 누출하는 방식으로 동작합니다.<br/>
+ * 따라서 키 값으로 동작하지 않고, 키와 관계 없이 요청이 들어오면 큐에 담아 두고 순서대로 처리합니다.
+ */
 public class LeakyBucketHandler implements RateLimitHandler {
 
     private final Deque<LeakyBucketInfo> deque;
@@ -32,7 +38,7 @@ public class LeakyBucketHandler implements RateLimitHandler {
 
     @Override
     public AbstractTokenInfo allowRequest(String key) {
-        LeakyBucketInfo bucketInfo = LeakyBucketInfo.of(capacity);
+        LeakyBucketInfo bucketInfo = LeakyBucketInfo.of(deque.size(), capacity);
         if (deque.size() < bucketInfo.getCapacity()) {
             deque.add(bucketInfo);
             if (scheduler.isShutdown()) {
@@ -48,13 +54,13 @@ public class LeakyBucketHandler implements RateLimitHandler {
 
     @Override
     public void endRequest() {
-        if (!deque.isEmpty()) {
-            deque.removeLast();
+        if (!this.deque.isEmpty()) {
+            this.deque.removeLast();
         }
     }
 
     private void startLeakTask() {
-        scheduler.scheduleAtFixedRate(() -> {
+        this.scheduler.scheduleAtFixedRate(() -> {
             synchronized (LeakyBucketHandler.this) {
                 while (!this.deque.isEmpty()) {
                     this.deque.poll();

--- a/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
+++ b/rate-limiter/src/main/java/com/innercicle/handler/LeakyBucketHandler.java
@@ -26,7 +26,6 @@ public class LeakyBucketHandler implements RateLimitHandler {
     private final Deque<LeakyBucketInfo> deque;
     private final int leakRate;                         // 누출 속도
     private final ScheduledExecutorService scheduler;   // 주기적으로 누출을 수행하는 스케줄러
-    private final int capacity;
     private final TimeUnit timeUnit;
 
     // Leaky Bucket 생성자


### PR DESCRIPTION
## 문제사항
누출 버킷 알고리즘의 `LeakyBucketHandler` 객체와 `LeakyBucketInfo` 양쪽에서 Deque를 갖고 있는 문제가 있고, endProcess 라는 불필요한 메소드 존재함.

## 해결 방안
- `LeakyBucketInfo` 객체에서 Deque를 제거하고, deque 의 사용중인 갯수만 넘겨서 기존 동작과 동일하도록 수정
- 재 수정으로 양쪽 모두 Deque를 갖고 있되, 생성된 `LeakyBucketInfo`를 캐시에 저장해서 꺼내 쓰는 로직으로 변경
- endProcess 메소드 삭제하고 endRequest 로 로직 이동
- 미사용 변수 제거 (capacity) 